### PR TITLE
style and functionality improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules/

--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -104,20 +104,19 @@ export default class Marketplace extends BasicList {
         sign = '*';
       }
 
+      let status = '×'
       let isInstalled = false;
       for (const e of extensions.all) {
         if (e.id === pkg.name) {
-          sign = '√';
+          status = '√';
           isInstalled = true;
           break;
         }
       }
-      if (!isInstalled && sign !== '*')
-        sign = '×';
 
       exts.push({
         name: pkg.name,
-        label: (`[${sign}] ${pkg.name} ${pkg.version}`).padEnd(30) + pkg.description,
+        label: (`[${status}] ${pkg.name}${sign} ${pkg.version}`).padEnd(30) + pkg.description,
         installed: isInstalled
       });
     }

--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -59,6 +59,9 @@ export default class Marketplace extends BasicList {
         }
       });
     }
+    items.sort((a, b) => {
+      return b.label.localeCompare(a.label);
+    })
 
     return items;
   }

--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -121,4 +121,20 @@ export default class Marketplace extends BasicList {
 
     return exts;
   }
+
+  public doHighlight(): void {
+    let {nvim} = this;
+    nvim.pauseNotification();
+    nvim.command('syntax match CocMarketplaceExtName /\\v%5v\\S+/', true);
+    nvim.command('syntax match CocMarketplaceExtStatus /\\v^\\[[√×\\*]\\]/', true);
+    nvim.command('syntax match CocMarketplaceExtVersion /\\v\\d+(\\.\\d+)*/', true);
+    nvim.command('syntax match CocMarketplaceExtDescription /\\v%30v.*$/', true);
+    nvim.command('highlight default link CocMarketplaceExtName String', true);
+    nvim.command('highlight default link CocMarketplaceExtStatus Type', true);
+    nvim.command('highlight default link CocMarketplaceExtVersion Tag', true);
+    nvim.command('highlight default link CocMarketplaceExtDescription Comment', true);
+    nvim.resumeNotification().catch(_e => {
+      // noop
+    });
+  }
 }

--- a/src/marketplace.ts
+++ b/src/marketplace.ts
@@ -101,17 +101,21 @@ export default class Marketplace extends BasicList {
         sign = '*';
       }
 
+      let isInstalled = false;
       for (const e of extensions.all) {
         if (e.id === pkg.name) {
-          sign = ' √';
+          sign = '√';
+          isInstalled = true;
           break;
         }
       }
+      if (!isInstalled && sign !== '*')
+        sign = '×';
 
       exts.push({
         name: pkg.name,
-        label: (pkg.name + sign).padEnd(30) + pkg.description,
-        installed: sign === ' √'
+        label: (`[${sign}] ${pkg.name} ${pkg.version}`).padEnd(30) + pkg.description,
+        installed: isInstalled
       });
     }
 


### PR DESCRIPTION
作了几点小小的改进

- 加入了扩展的版本号显示
- 加了语法高亮
- 默认对扩展根据“已安装，未安装”进行分组，这样方便查看

在我的主题上显示是这样子

![2019-06-05 14-41-13 的屏幕截图](https://user-images.githubusercontent.com/20282795/58936148-ab9a2080-87a1-11e9-9276-1924ca95601f.png)


related: #1 